### PR TITLE
Readd wayland socket

### DIFF
--- a/org.gnucash.GnuCash.json
+++ b/org.gnucash.GnuCash.json
@@ -9,6 +9,7 @@
   "rename-desktop-file": "gnucash.desktop",
   "rename-appdata-file": "gnucash.appdata.xml",
   "finish-args": [
+    "--socket=wayland",
     "--socket=x11", "--share=ipc",
     "--share=network",
     "--filesystem=home",


### PR DESCRIPTION
Since GnuCash uses gtk3 now there should be no need to fall back to xwayland.