### PR TITLE
boost program options required in gnucash 4

### DIFF
--- a/modules/boost.json
+++ b/modules/boost.json
@@ -9,7 +9,7 @@
         }
     ],
     "build-commands": [
-        "./bootstrap.sh --prefix=/app --with-libraries=locale,filesystem,system,date_time,regex",
+        "./bootstrap.sh --prefix=/app --with-libraries=locale,filesystem,system,date_time,regex,program_options",
         "./b2 headers",
         "./b2 -j$FLATPAK_BUILDER_N_JOBS install variant=release --layout=system"
     ]


### PR DESCRIPTION
Build is failing due to missing program_options in boost

https://flathub.org/builds/#/builders/32/builds/22633