### PR TITLE
Update runtime to 3.38

### DIFF
--- a/modules/mariadb.json
+++ b/modules/mariadb.json
@@ -11,7 +11,8 @@
         "-DWITHOUT_TOKUDB=1",
         "-DWITHOUT_EXAMPLE_STORAGE_ENGINE=1",
         "-DWITHOUT_FEDERATED_STORAGE_ENGINE=1",
-        "-DWITHOUT_PBXT_STORAGE_ENGINE=1"
+        "-DWITHOUT_PBXT_STORAGE_ENGINE=1",
+        "-DPLUGIN_AUTH_PAM=NO"
     ],
     "post-install": [
         "make -C libmysql install",
@@ -25,8 +26,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "http://ftp.hosteurope.de/mirror/archive.mariadb.org/mariadb-10.1.32/source/mariadb-10.1.32.tar.gz",
-            "sha256": "0e2aae6a6a190d07c8e36e87dd43377057fa82651ca3c583462563f3e9369096"
+            "url": "http://ftp.hosteurope.de/mirror/archive.mariadb.org/mariadb-10.1.48/source/mariadb-10.1.48.tar.gz",
+            "sha256": "069d58b1e2c06bb1e6c31249eda34138f41fb8ae3dec7ecaeba8035812c87cf9"
         }
     ],
     "modules": [
@@ -39,8 +40,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/jemalloc/jemalloc/releases/download/5.0.1/jemalloc-5.0.1.tar.bz2",
-                    "sha256": "4814781d395b0ef093b21a08e8e6e0bd3dab8762f9935bbfb71679b0dea7c3e9"
+                    "url": "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2",
+                    "sha256": "34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6"
                 }
             ]
         },

--- a/modules/perl.json
+++ b/modules/perl.json
@@ -15,8 +15,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.cpan.org/src/5.0/perl-5.28.0.tar.gz",
-                    "sha256": "7e929f64d4cb0e9d1159d4a59fc89394e27fa1f7004d0836ca0d514685406ea8"
+                    "url": "https://www.cpan.org/src/5.0/perl-5.32.0.tar.gz",
+                    "sha256": "efeb1ce1f10824190ad1cadbcccf6fdb8a5d37007d0100d2d9ae5f2b5900c0b4"
                 },
                 {
                     "type": "script",

--- a/org.gnucash.GnuCash.json
+++ b/org.gnucash.GnuCash.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnucash.GnuCash",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.36",
+  "runtime-version": "3.38",
   "sdk": "org.gnome.Sdk",
   "command": "gnucash",
   "copy-icon": true,
@@ -26,11 +26,11 @@
   "modules": [
     "modules/guile.json",
     "modules/libofx.json",
+    "modules/boost.json",
     "modules/mariadb.json",
     "modules/postgresql.json",
     "modules/libdbi.json",
     "modules/aqbanking.json",
-    "modules/boost.json",
     "modules/googletest.json",
     "modules/perl.json",
     "modules/swig.json",


### PR DESCRIPTION
To have it working correctly, mariadb and perl versions should be bumped as well.
mariadb now compile with PAM by default, so you will need to disable it.