### PR TITLE
Release GnuCash 4.12-2

### DIFF
--- a/gnucash.releases.xml
+++ b/gnucash.releases.xml
@@ -1,6 +1,7 @@
-<release version="4.12-1" date="2022-10-16">
+<release version="4.12-2" date="2022-10-22">
     <description>
       <ul>
+        <li>2022-10-22 - Update Gnome Platform runtime to 42. (John Ralls)</li>
         <li>2022-10-16 - Update Finance::Quote to 1.53 (Geert Janssens)</li>
         <li>2022-09-25 - Package gnucash 4.12. (John Ralls)</li>
         <li>2022-09-25 - Update to upstream 4.12. (John Ralls)</li>

--- a/org.gnucash.GnuCash.json
+++ b/org.gnucash.GnuCash.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnucash.GnuCash",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "41",
+  "runtime-version": "42",
   "sdk": "org.gnome.Sdk",
   "command": "gnucash",
   "copy-icon": true,


### PR DESCRIPTION
Because someone at flathub decided that upstream administrators should have to create a pull request to make a release.