### PR TITLE
Package GnuCash 5.0-1

### DIFF
--- a/gnucash.releases.xml
+++ b/gnucash.releases.xml
@@ -1,7 +1,7 @@
-<release version="5.0" date="2023-03-26">
+<release version="5.0-1" date="2023-03-28">
     <description>
       <ul>
-        <li>2023-03-26 - Update to upstream 5.0 (John Ralls)</li>
+        <li>2023-03-28 - Update to upstream 5.0-1 (John Ralls)</li>
       </ul>
     </description>
 </release>

--- a/modules/finance-quote-sources.json
+++ b/modules/finance-quote-sources.json
@@ -103,6 +103,7 @@
       "(make_install perl-libs/Spreadsheet-ParseExcel)",
       "(make_install perl-libs/Spreadsheet-XLSX)",
       "(make_install perl-libs/JSON)",
+      "(make_install perl-libs/JSON-Parse)",
       "(make_install perl-libs/HTML-Element-Extended)",
       "(make_install perl-libs/HTML-TableExtract)",
       "(make_install perl-libs/Text-Template)",
@@ -393,6 +394,12 @@
     "sha256": "df8b5143d9a7de99c47b55f1a170bd1f69f711935c186a6dc0ab56dd05758e35",
     "type": "archive",
     "url": "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-4.10.tar.gz"
+  },
+  {
+    "dest": "perl-libs/JSON-Parse",
+    "sha256": "6273180f9392497401ddd6d820706f5aa86c1be88891dd6aab4d906b5cff66d9",
+    "type": "archive",
+    "url": "https://cpan.metacpan.org/authors/id/B/BK/BKB/JSON-Parse-0.62.tar.gz"
   },
   {
     "dest": "perl-libs/LWP-MediaTypes",

--- a/org.gnucash.GnuCash.json
+++ b/org.gnucash.GnuCash.json
@@ -40,7 +40,7 @@
         "buildsystem": "cmake-ninja",
         "config-opts": [
             "-DBOOST_ROOT=/app",
-            "-DGNUCASH_BUILD_ID='Flathub 5.0'"
+            "-DGNUCASH_BUILD_ID='Flathub 5.0-1'"
         ],
         "cleanup": [
             "/share/info",


### PR DESCRIPTION
Fixes [Bug 798805](https://bugs.gnucash.org/show_bug.cgi?id=798805) by adding perl JSON::Parse to the flatpak.