### PR TITLE
Update gwenhywfar to make aqbanking work again with some banks

### DIFF
--- a/modules/aqbanking.json
+++ b/modules/aqbanking.json
@@ -45,8 +45,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.aquamaniac.de/rdm/attachments/download/465/gwenhywfar-5.10.1.tar.gz",
-                    "sha256": "a2f60a9dde5da27e57e0e5ef5f8931f495c1d541ad90a841e2b6231565547160"
+                    "url": "https://www.aquamaniac.de/rdm/attachments/download/501/gwenhywfar-5.10.2.tar.gz",
+                    "sha256": "60a7da03542865501208f20e18de32b45a75e3f4aa8515ca622b391a2728a9e1"
                 }
             ]
         },


### PR DESCRIPTION
Updating gwenhywfar to 5.10.2 makes aqbanking work with some banks (e.g. 1822direkt) again.